### PR TITLE
Revert "Ensure volume GetCloudProvider code uses cloud config"

### DIFF
--- a/pkg/volume/aws_ebs/aws_util.go
+++ b/pkg/volume/aws_ebs/aws_util.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/aws"
 	"k8s.io/kubernetes/pkg/util/keymutex"
 	"k8s.io/kubernetes/pkg/util/runtime"
@@ -107,7 +108,7 @@ func (util *AWSDiskUtil) DetachDisk(c *awsElasticBlockStoreCleaner) error {
 }
 
 func (util *AWSDiskUtil) DeleteVolume(d *awsElasticBlockStoreDeleter) error {
-	cloud, err := getCloudProvider(d.awsElasticBlockStore.plugin)
+	cloud, err := getCloudProvider()
 	if err != nil {
 		return err
 	}
@@ -128,7 +129,7 @@ func (util *AWSDiskUtil) DeleteVolume(d *awsElasticBlockStoreDeleter) error {
 // CreateVolume creates an AWS EBS volume.
 // Returns: volumeID, volumeSizeGB, labels, error
 func (util *AWSDiskUtil) CreateVolume(c *awsElasticBlockStoreProvisioner) (string, int, map[string]string, error) {
-	cloud, err := getCloudProvider(c.awsElasticBlockStore.plugin)
+	cloud, err := getCloudProvider()
 	if err != nil {
 		return "", 0, nil, err
 	}
@@ -174,7 +175,7 @@ func attachDiskAndVerify(b *awsElasticBlockStoreBuilder, xvdBeforeSet sets.Strin
 	for numRetries := 0; numRetries < maxRetries; numRetries++ {
 		var err error
 		if awsCloud == nil {
-			awsCloud, err = getCloudProvider(b.awsElasticBlockStore.plugin)
+			awsCloud, err = getCloudProvider()
 			if err != nil || awsCloud == nil {
 				// Retry on error. See issue #11321
 				glog.Errorf("Error getting AWSCloudProvider while detaching PD %q: %v", b.volumeID, err)
@@ -249,7 +250,7 @@ func detachDiskAndVerify(c *awsElasticBlockStoreCleaner) {
 	for numRetries := 0; numRetries < maxRetries; numRetries++ {
 		var err error
 		if awsCloud == nil {
-			awsCloud, err = getCloudProvider(c.awsElasticBlockStore.plugin)
+			awsCloud, err = getCloudProvider()
 			if err != nil || awsCloud == nil {
 				// Retry on error. See issue #11321
 				glog.Errorf("Error getting AWSCloudProvider while detaching PD %q: %v", c.volumeID, err)
@@ -347,19 +348,12 @@ func pathExists(path string) (bool, error) {
 }
 
 // Return cloud provider
-func getCloudProvider(plugin *awsElasticBlockStorePlugin) (*aws.AWSCloud, error) {
-	if plugin == nil {
-		return nil, fmt.Errorf("Failed to get AWS Cloud Provider. plugin object is nil.")
-	}
-	if plugin.host == nil {
-		return nil, fmt.Errorf("Failed to get AWS Cloud Provider. plugin.host object is nil.")
+func getCloudProvider() (*aws.AWSCloud, error) {
+	awsCloudProvider, err := cloudprovider.GetCloudProvider("aws", nil)
+	if err != nil || awsCloudProvider == nil {
+		return nil, err
 	}
 
-	cloudProvider := plugin.host.GetCloudProvider()
-	awsCloudProvider, ok := cloudProvider.(*aws.AWSCloud)
-	if !ok || awsCloudProvider == nil {
-		return nil, fmt.Errorf("Failed to get AWS Cloud Provider. plugin.host.GetCloudProvider returned %v instead", cloudProvider)
-	}
-
-	return awsCloudProvider, nil
+	// The conversion must be safe otherwise bug in GetCloudProvider()
+	return awsCloudProvider.(*aws.AWSCloud), nil
 }

--- a/test/e2e/volume_provisioning.go
+++ b/test/e2e/volume_provisioning.go
@@ -50,7 +50,7 @@ var _ = Describe("Dynamic provisioning", func() {
 
 	Describe("DynamicProvisioner", func() {
 		It("should create and delete persistent volumes", func() {
-			SkipUnlessProviderIs("openstack", "gce", "aws", "gke")
+			SkipUnlessProviderIs("openstack", "gce", "aws")
 			By("creating a claim with a dynamic provisioning annotation")
 			claim := createClaim(ns)
 			defer func() {


### PR DESCRIPTION
This reverts commit c04108e90ca28e341af2bd72bcef6e09e7400763.
CloudProvider being Rancher in our case, not aws/gce, makes it impossible to use these providers specific plugins

@ibuildthecloud 