### PR TITLE
Cache host information 

### DIFF
--- a/pkg/kubelet/cadvisor/rancher/client.go
+++ b/pkg/kubelet/cadvisor/rancher/client.go
@@ -274,7 +274,7 @@ func (self *Client) getEventStreamingData(url string, einfo chan *info.Event) er
 	for {
 		err := dec.Decode(m)
 		if err != nil {
-			if err == io.EOF {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
 				break
 			}
 			// if called without &stream=true will not be able to parse event and will trigger fatal


### PR DESCRIPTION
and fetch from cache when rancher service is unavailable (going through an upgrade for example). This is to avoid pod eviction on the nodes in non-ready status. 

Item is removed from cache when host is removed in Rancher