### PR TITLE
Add the '--advertise-address=' start parameter to kube-apiserver

### DIFF
--- a/rancher-k8s-images/k8s/entry.sh
+++ b/rancher-k8s-images/k8s/entry.sh
@@ -34,8 +34,13 @@ users:
 EOF
 fi
 
+CONTAINERIP=$(curl -s http://rancher-metadata/2015-12-19/self/container/ips/0)
+
 if [ "$1" == "kubelet" ]; then
     /usr/bin/share-mnt /var/lib/kubelet /sys -- kubelet-start.sh "$@"
+elif [ "$1" == "kube-apiserver" ]; then
+    set -- "$@" "--advertise-address=$CONTAINERIP"
+    exec "$@"
 else
     exec "$@"
 fi


### PR DESCRIPTION
Add the '--advertise-address=' start parameter to kube-apiserver after looking up the container ipadress from rancher metadata

https://github.com/rancher/rancher/issues/5180