### PR TITLE
fix hostname resolution issue

### DIFF
--- a/rancher-k8s-images/k8s/kubelet-start.sh
+++ b/rancher-k8s-images/k8s/kubelet-start.sh
@@ -2,4 +2,11 @@
 
 mount --rbind /host/dev /dev
 
-exec "$@"
+HOST_ID=$(curl -s http://169.254.169.250/latest/self/host/hostId)
+HOSTNAME_OVERRIDE=$(curl -s -u $CATTLE_ACCESS_KEY:$CATTLE_SECRET_KEY "$CATTLE_URL/hosts/1h$HOST_ID/ipaddresses" | jq -r '.data[0].address')
+
+CMD=$(eval echo "$@")
+
+ARR_CMD=($CMD)
+
+exec "${ARR_CMD[@]}"


### PR DESCRIPTION
With this change, all the Kubernetes nodes will be named and resolved using IP addresses instead of hostnames. Without this change, commands such as 'exec', 'logs', and 'attach' returned error if the hostnames were not resolvable. 

As mentioned above, nodes are named after IP addresses
```
> kubectl get nodes
NAME              STATUS    AGE
104.131.154.216   Ready     34m
107.170.196.120   Ready     34m
198.199.106.118   Ready     34m
```

The solution requires that the kubelet is started with `--hostname-override=$RANCHER_IP_ADDRESS`. If `--hostname-override` is not set, then it works just as it did earlier.

This is the change to my compose file - https://github.com/wlan0/rancher-catalog/commit/cd76a80e6d6ad8ad36e6ccbb3be5e7e79c75a076

@alena @ibuildthecloud 

Fixes https://github.com/rancher/rancher/issues/4384 https://github.com/rancher/rancher/issues/4664