### PR TITLE
set external_id for rancher lb svc

### DIFF
--- a/pkg/cloudprovider/providers/rancher/rancher.go
+++ b/pkg/cloudprovider/providers/rancher/rancher.go
@@ -173,6 +173,7 @@ func (r *CloudProvider) EnsureLoadBalancer(service *api.Service, hosts []string)
 			LaunchConfig: &client.LaunchConfig{
 				Ports: lbPorts,
 			},
+			ExternalId: string(service.UID),
 		}
 
 		lb, err = r.client.LoadBalancerService.Create(lb)


### PR DESCRIPTION
@ibuildthecloud this PR sets externalId on Rancher Lb service to uuid of corresponding k8s LB service. The only one concern I have: we also propagate k8s lb service to rancher with this externalId, so we end up having 2 services of diff kind (lbService and kubernetesService) having the same external_id:

```
mysql> select id, name, kind, external_id from service where id in (96,97);
+----+-------------------------------------+---------------------+--------------------------------------+
| id | name                                | kind                | external_id                          |
+----+-------------------------------------+---------------------+--------------------------------------+
| 96 | lbnginx                             | kubernetesService   | 4c2d8022-4fb2-11e6-8a5e-0269d699abef |
| 97 | lb-a4c2d80224fb211e68a5e0269d699abe | loadBalancerService | 4c2d8022-4fb2-11e6-8a5e-0269d699abef                                 |
+----+-------------------------------------+---------------------+--------------------------------------+
```

Here is corresponding cattle PR (we didn't allow setting externalId for service before):
https://github.com/rancher/cattle/pull/1831