### PR TITLE
Update Dockerfile for k8s image

### DIFF
--- a/rancher-k8s-images/k8s/Dockerfile
+++ b/rancher-k8s-images/k8s/Dockerfile
@@ -13,6 +13,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -y \
     nfs-common \
     jq \
     unzip \
+    git \
+    glusterfs-client \
     && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y \
     && DEBIAN_FRONTEND=noninteractive apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
This change is in reference with

https://github.com/rancher/rancher/issues/4976
For rancher to support gitRepo from k8s, kubelet needs git installed.

https://github.com/rancher/rancher/issues/4348
For rancher to support glusterfs volume from k8s, kubelet needs glusterfs-client installed.