### PR TITLE
fix kubedns-sa.yaml missing "namespace: kube-system" value

### DIFF
--- a/cluster/addons/dns/kubedns-sa.yaml
+++ b/cluster/addons/dns/kubedns-sa.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kube-dns
+  namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile


### PR DESCRIPTION
(cherry picked from commit 7978ad1)