### PR TITLE
Disable even more azure support

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/plugins.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/plugins.go
@@ -18,7 +18,7 @@ package auth
 
 import (
 	// Initialize all known client auth plugins.
-	_ "k8s.io/client-go/plugin/pkg/client/auth/azure"
+	// _ "k8s.io/client-go/plugin/pkg/client/auth/azure"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/openstack"

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -34,7 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtimeutils "k8s.io/apimachinery/pkg/util/runtime"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/kubernetes/pkg/cloudprovider/providers/azure"
+	// "k8s.io/kubernetes/pkg/cloudprovider/providers/azure"
 	gcecloud "k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 	"k8s.io/kubernetes/pkg/kubectl/util/logs"
 	"k8s.io/kubernetes/pkg/version"
@@ -128,7 +128,7 @@ func setupProviderConfig() error {
 				cloudConfig.ConfigFile, err)
 		}
 		defer config.Close()
-		cloudConfig.Provider, err = azure.NewCloud(config)
+		// cloudConfig.Provider, err = azure.NewCloud(config)
 	}
 
 	return nil

--- a/test/e2e/framework/pv_util.go
+++ b/test/e2e/framework/pv_util.go
@@ -713,19 +713,19 @@ func createPD(zone string) (string, error) {
 
 		volumeName := "aws://" + az + "/" + awsID
 		return volumeName, nil
-	} else if TestContext.Provider == "azure" {
-		pdName := fmt.Sprintf("%s-%s", TestContext.Prefix, string(uuid.NewUUID()))
-		azureCloud, err := GetAzureCloud()
+		//} else if TestContext.Provider == "azure" {
+		//	pdName := fmt.Sprintf("%s-%s", TestContext.Prefix, string(uuid.NewUUID()))
+		//	azureCloud, err := GetAzureCloud()
 
-		if err != nil {
-			return "", err
-		}
+		//	if err != nil {
+		//		return "", err
+		//	}
 
-		_, diskURI, _, err := azureCloud.CreateVolume(pdName, "" /* account */, "" /* sku */, "" /* location */, 1 /* sizeGb */)
-		if err != nil {
-			return "", err
-		}
-		return diskURI, nil
+		//	_, diskURI, _, err := azureCloud.CreateVolume(pdName, "" /* account */, "" /* sku */, "" /* location */, 1 /* sizeGb */)
+		//	if err != nil {
+		//		return "", err
+		//	}
+		//	return diskURI, nil
 	} else {
 		return "", fmt.Errorf("provider does not support volume creation")
 	}
@@ -765,17 +765,17 @@ func deletePD(pdName string) error {
 			}
 		}
 		return nil
-	} else if TestContext.Provider == "azure" {
-		azureCloud, err := GetAzureCloud()
-		if err != nil {
-			return err
-		}
-		err = azureCloud.DeleteVolume(pdName)
-		if err != nil {
-			Logf("failed to delete Azure volume %q: %v", pdName, err)
-			return err
-		}
-		return nil
+		//} else if TestContext.Provider == "azure" {
+		//	azureCloud, err := GetAzureCloud()
+		//	if err != nil {
+		//		return err
+		//	}
+		//	err = azureCloud.DeleteVolume(pdName)
+		//	if err != nil {
+		//		Logf("failed to delete Azure volume %q: %v", pdName, err)
+		//		return err
+		//	}
+		//	return nil
 	} else {
 		return fmt.Errorf("provider does not support volume deletion")
 	}

--- a/test/e2e/framework/service_util.go
+++ b/test/e2e/framework/service_util.go
@@ -39,7 +39,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
-	azurecloud "k8s.io/kubernetes/pkg/cloudprovider/providers/azure"
+	// azurecloud "k8s.io/kubernetes/pkg/cloudprovider/providers/azure"
 	gcecloud "k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 	testutils "k8s.io/kubernetes/test/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
@@ -1444,10 +1444,10 @@ func EnableAndDisableInternalLB() (enable func(svc *v1.Service), disable func(sv
 		}
 	case "azure":
 		enable = func(svc *v1.Service) {
-			svc.ObjectMeta.Annotations = map[string]string{azurecloud.ServiceAnnotationLoadBalancerInternal: "true"}
+			// svc.ObjectMeta.Annotations = map[string]string{azurecloud.ServiceAnnotationLoadBalancerInternal: "true"}
 		}
 		disable = func(svc *v1.Service) {
-			svc.ObjectMeta.Annotations = map[string]string{azurecloud.ServiceAnnotationLoadBalancerInternal: "false"}
+			// svc.ObjectMeta.Annotations = map[string]string{azurecloud.ServiceAnnotationLoadBalancerInternal: "false"}
 		}
 	}
 

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -82,7 +82,7 @@ import (
 	extensionsinternal "k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/client/conditions"
-	"k8s.io/kubernetes/pkg/cloudprovider/providers/azure"
+	// "k8s.io/kubernetes/pkg/cloudprovider/providers/azure"
 	gcecloud "k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 	"k8s.io/kubernetes/pkg/controller"
 	nodectlr "k8s.io/kubernetes/pkg/controller/node"
@@ -4959,13 +4959,13 @@ func CreateEmptyFileOnPod(namespace string, podName string, filePath string) err
 }
 
 // GetAzureCloud returns azure cloud provider
-func GetAzureCloud() (*azure.Cloud, error) {
-	cloud, ok := TestContext.CloudConfig.Provider.(*azure.Cloud)
-	if !ok {
-		return nil, fmt.Errorf("failed to convert CloudConfig.Provider to Azure: %#v", TestContext.CloudConfig.Provider)
-	}
-	return cloud, nil
-}
+//func GetAzureCloud() (*azure.Cloud, error) {
+//	cloud, ok := TestContext.CloudConfig.Provider.(*azure.Cloud)
+//	if !ok {
+//		return nil, fmt.Errorf("failed to convert CloudConfig.Provider to Azure: %#v", TestContext.CloudConfig.Provider)
+//	}
+//	return cloud, nil
+//}
 
 func PrintSummaries(summaries []TestDataSummary, testBaseName string) {
 	now := time.Now()


### PR DESCRIPTION
- Disable references in tests/e2e so that make can complete without failing
- Disable reference in client-go so that a newer version of azure/go-autorest can be pulled in

My main goal is to disable to reference in client-go, but I ended up making the changes in tests/e2e so that when you run `make` (which builds all the binaries), the build will actually complete without compilation errors. If you dont want the tests/e2e changes in @ibuildthecloud, I can roll them back, but I'd like to know how you validate that the change you made in here will compile when pulled into rancher/rancher.


See https://github.com/rancher/rancher/pull/13967 if you need more details on why/how this is needed
