### PR TITLE
Change buildDate to align to kubernetes ISO8601 standard

### DIFF
--- a/tag.sh
+++ b/tag.sh
@@ -32,7 +32,7 @@ go run ./pkg/generated/openapi/gen/main.go > ./pkg/generated/openapi/gen/openapi
 mv ./pkg/generated/openapi/gen/openapi.go ./pkg/generated/openapi/openapi.go
 rm -f ./pkg/generated/openapi/zz_generated.openapi.go
 
-buildDate=$(date -u '+%FT%RZ')
+buildDate=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 versionFiles="
     pkg/version/base.go
     pkg/kubectl/version/base.go


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
The change updates the buildDate to include seconds. Most projects appear to assume that a full ISO8601 date string will be present in this value.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/rancher/k3s/issues/808

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
