### PR TITLE
[v1.26] changes for cri-dockerd 

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -261,6 +261,7 @@ type Dependencies struct {
 	PodStartupLatencyTracker util.PodStartupLatencyTracker
 	// remove it after cadvisor.UsingLegacyCadvisorStats dropped.
 	useLegacyCadvisorStats bool
+	remoteRuntimeEndpoint  string
 }
 
 // makePodSourceConfig creates a config.PodConfig from the given
@@ -319,6 +320,7 @@ func PreInitRuntimeService(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	}
 
 	kubeDeps.useLegacyCadvisorStats = cadvisor.UsingLegacyCadvisorStats(remoteRuntimeEndpoint)
+	kubeDeps.remoteRuntimeEndpoint = remoteRuntimeEndpoint
 	return nil
 }
 
@@ -620,17 +622,22 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		klet.runtimeClassManager = runtimeclass.NewManager(kubeDeps.KubeClient)
 	}
 
-	// setup containerLogManager for CRI container runtime
-	containerLogManager, err := logs.NewContainerLogManager(
-		klet.runtimeService,
-		kubeDeps.OSInterface,
-		kubeCfg.ContainerLogMaxSize,
-		int(kubeCfg.ContainerLogMaxFiles),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize container log manager: %v", err)
+	// cri-dockerd does not support rotating logs, same as internal dockershim
+	if cadvisor.UsingCriDockerdSocket(kubeDeps.remoteRuntimeEndpoint) {
+		klet.containerLogManager = logs.NewStubContainerLogManager()
+	} else {
+		// setup containerLogManager for CRI container runtime
+		containerLogManager, err := logs.NewContainerLogManager(
+			klet.runtimeService,
+			kubeDeps.OSInterface,
+			kubeCfg.ContainerLogMaxSize,
+			int(kubeCfg.ContainerLogMaxFiles),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize container log manager: %v", err)
+		}
+		klet.containerLogManager = containerLogManager
 	}
-	klet.containerLogManager = containerLogManager
 
 	klet.reasonCache = NewReasonCache()
 	klet.workQueue = queue.NewBasicWorkQueue(klet.clock)


### PR DESCRIPTION
**Issue:** https://github.com/rancher/rancher/issues/39819
Internal dockershim never supported rotating logs for docker, see https://github.com/kubernetes/kubernetes/blob/v1.23.15/pkg/kubelet/kubelet.go#L643. 

With introduction of CRI, it was expected for runtimes to add their own support and kubelet relies on `runtimeService` for the actual log. See https://github.com/kubernetes/kubernetes/blob/84e1fc493a47446df2e155e70fca768d2653a398/pkg/kubelet/logs/container_log_manager.go#L252. 

Because internal dockershim didn't support this feature, cri-dockerd doesn't have support for it either. It logs error that is seen constantly in logs: https://github.com/Mirantis/cri-dockerd/blob/master/core/logs.go#L47 https://github.com/Mirantis/cri-dockerd/issues/35#issuecomment-1365522575 

**Workaround:**
As mentioned in https://github.com/rancher/rancher/issues/39819#issuecomment-1472278470, rely on docker's `max-size` flag to perform log rotation. 
Note that it is required for this flag to be <= kubelet's `container-log-max-size` because it controls how often kubelet's rotateLogs is called. https://github.com/kubernetes/kubernetes/blob/v1.26.7/pkg/kubelet/logs/container_log_manager.go#L263 

**Solution:**
Use stub log manager for cri-dockerd runtime to maintain the internal dockershim's behavior. This will ensure the behavior remains same <v1.24 and users can configure docker daemon's capabilities to rotate logs.   