### PR TITLE
[v1.28] remove setup-go step from gha release for go version<1.22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,11 +28,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
       - name: build with Dapper
         run: dapper ci
         


### PR DESCRIPTION
https://github.com/rancher/kubernetes/pull/152