### PR TITLE
Enhance CI process with self-hosted runners, artifacts and Github App token

### DIFF
--- a/.github/workflows/kubernetes-sync.yml
+++ b/.github/workflows/kubernetes-sync.yml
@@ -24,12 +24,6 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
 
-      # - name: Retrieve token from vault
-      #   uses: rancher-eio/read-vault-secrets@main
-      #   with:
-      #     secrets: |
-      #       secret/data/github/repo/${{ github.repository }}/github-token/credentials token | PAT_TOKEN ;
-
       - name: Fetch the new tags from kubernetes/kubernetes repository
         run: $GITHUB_WORKSPACE/rancher-k8s/scripts/check-for-new-tag.sh
 
@@ -38,22 +32,20 @@ jobs:
         run: |
           cd rancher-k8s
           $GITHUB_WORKSPACE/rancher-k8s/scripts/create-release-branch.sh
-        env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
 
-      # - name: 'Tar files'
-      #   run: |
-      #     tar -czf rancher-k8s.tar.gz -C rancher-k8s .
+      - name: 'Tar files'
+        run: |
+          tar -czf rancher-k8s.tar.gz -C rancher-k8s .
       
-      # - name: Push git repo to artifacts
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: git-repo
-      #     path: rancher-k8s.tar.gz
+      - name: Push git repo to artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: git-repo
+          path: rancher-k8s.tar.gz
 
   build-and-validate:
     needs: create-branches
-    runs-on: ubuntu-latest
+    runs-on: runs-on,runner=4cpu-linux-x64,run-id=${{ github.run_id }}
     container:
       image: rancher/dapper:v0.6.0
     permissions:
@@ -70,37 +62,49 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
 
-      - name: Checkout repository with branch ${{ matrix.branches }}
-        uses: actions/checkout@v4
+      - name: Download git repo from artifact
+        uses: actions/download-artifact@v4
         with:
-          ref: ${{ matrix.branches }}
+          name: git-repo
 
-      # - name: Download git repo from artifact
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: git-repo
-
-      # - name: Extract Artifact
-      #   run: |
-      #     tar -zxf rancher-k8s.tar.gz
-      #     rm rancher-k8s.tar.gz
-
-      # - name: Retrieve token from vault
-      #   uses: rancher-eio/read-vault-secrets@main
-      #   with:
-      #     secrets: |
-      #       secret/data/github/repo/${{ github.repository }}/github-token/credentials token | PAT_TOKEN ;
+      - name: Extract Artifact
+        run: |
+          tar -zxf rancher-k8s.tar.gz
+          rm rancher-k8s.tar.gz
 
       - name: Build with Dapper for ${{ matrix.branches }}
-        run: dapper ci
+        run: |
+          git checkout ${{ matrix.branches }}
+          dapper ci
 
       - name: List the bin for ${{ matrix.branches }}
         run: ls -lR output/bin
+      
+      - name: Read App Secrets
+        uses: rancher-eio/read-vault-secrets@main
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/github/app-credentials appId | APP_ID ;
+            secret/data/github/repo/${{ github.repository }}/github/app-credentials privateKey | PRIVATE_KEY
+
+      - name: Create App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ env.APP_ID }}
+          private-key: ${{ env.PRIVATE_KEY }}
 
       - name: Push release tag for ${{ matrix.branches }}
         run: |
           # To stash any changes created by dapper CI run
           git stash --all
+
+          if ! $(git push --quiet --no-progress origin $RELEASE_BRANCH > /dev/null); then
+            echo "[ERROR] Failed while pushing the branch $RELEASE_BRANCH to rancher repository. Skipping the version $RELEASE_BRANCH."
+            exit 1
+          else
+            echo "[INFO] Successfully pushed branch $RELEASE_BRANCH: https://github.com/rancher/kubernetes/tree/$RELEASE_BRANCH"
+          fi
 
           # Remove the 'release-' prefix to create the tag name
           TAG="${RELEASE_BRANCH#release-}"
@@ -120,5 +124,5 @@ jobs:
               echo "[INFO] Successfully pushed tag $TAG: https://github.com/rancher/kubernetes/releases/tag/$TAG"
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           RELEASE_BRANCH: ${{ matrix.branches }}

--- a/scripts/create-release-branch.sh
+++ b/scripts/create-release-branch.sh
@@ -103,14 +103,8 @@ for tag in $NEW_TAGS; do
     done
 
     if [[ $FAIL == 0 ]]; then
-        echo "[INFO] Cherry pick completed successfully. Pushing branch release-${tag} to rancher repository."
-        if ! $(git push --quiet --no-progress origin release-${tag} > /dev/null); then
-            echo "[WARN] Failed while pushing the branch release-${tag} to rancher repository. Skipping the version ${tag}."
-            continue
-        else
-            NEW_RELEASE_BRANCHES+=( "release-${tag}" )
-            echo "[INFO] Successfully pushed branch release-${tag}: https://github.com/rancher/kubernetes/tree/release-${tag}"
-        fi
+        echo "[INFO] Cherry pick completed successfully."
+        NEW_RELEASE_BRANCHES+=( "release-${tag}" )
     else
         git cherry-pick --abort
     fi


### PR DESCRIPTION
## Updates:

- Implement support for self-hosted runners and artifact management to trigger CI check before creating release branches.
- Introduce GitHub App token to trigger release CI for the tags when created through GHA workflow.