### PR TITLE
[workflow] Added skip mechanism for automation script

### DIFF
--- a/.github/workflows/kubernetes-sync.yml
+++ b/.github/workflows/kubernetes-sync.yml
@@ -3,7 +3,7 @@ name: Sync with Kubernetes releases and cherry-pick Rancher-specific changes
 on:
   schedule:
     - cron: "0 0 * * *" # Runs daily at midnight
-  workflow_dispatch:
+  workflow_dispatch:  
 
 jobs:
   create-branches:
@@ -45,6 +45,7 @@ jobs:
 
       - name: Create new release branches in rancher/kubernetes
         id: create-release-branches
+        if: ${{ env.NEW_TAGS != '' }}  # Run only if there are new tags
         run: |
           cd rancher-k8s
           $GITHUB_WORKSPACE/rancher-k8s/scripts/create-release-branch.sh
@@ -62,6 +63,7 @@ jobs:
   build-and-validate:
     needs: create-branches
     runs-on: runs-on,runner=4cpu-linux-x64,run-id=${{ github.run_id }}
+    if: ${{ needs.create-branches.outputs.new-release-branches != '[]' && needs.create-branches.outputs.new-release-branches != '' }}
     container:
       image: rancher/dapper:v0.6.0
     permissions:

--- a/scripts/check-for-new-tag.sh
+++ b/scripts/check-for-new-tag.sh
@@ -51,15 +51,17 @@ done
 # Print the new tags
 if [ ${#new_tags[@]} -eq 0 ]; then
     echo "[ERROR] No new tags found in upstream kubernetes."
-    exit 1
+    # Set an empty NEW_TAGS environment variable
+    echo "NEW_TAGS=" >> $GITHUB_ENV
+    exit 0
 else
     echo "[INFO] New tags to create branches in rancher/kubernetes:"
     for tag in "${new_tags[@]}"; do
         echo "- $tag"
     done
-fi
 
-echo "NEW_TAGS=${new_tags[@]}" >> $GITHUB_ENV
+    echo "NEW_TAGS=${new_tags[@]}" >> $GITHUB_ENV
+fi
 
 # Clean up temporary files
 rm -f "$rancher_tags_file" "$upstream_tags_file"


### PR DESCRIPTION
Added a condition to skip the build-and-validate job when no new release branches are created. This prevents unnecessary job runs and improves workflow efficiency.